### PR TITLE
SimpleTcpServer.Start() should throw exception if failed.

### DIFF
--- a/SimpleTCP.Tests/ServerTests.cs
+++ b/SimpleTCP.Tests/ServerTests.cs
@@ -6,19 +6,36 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace SimpleTCP.Tests
 {
 	[TestClass]
-	public class ServerTests
+	public class ServerTests : IDisposable
 	{
+		readonly int _serverPort = 8911;
+		readonly SimpleTcpServer _server;
+
+		public ServerTests()
+		{
+			_server = new SimpleTcpServer().Start(_serverPort);
+		}
+
+		public void Dispose()
+		{
+			if (_server.IsStarted)
+				_server.Stop();
+		}
+
 		[TestMethod]
 		public void Listening_port_opens_and_closes_when_server_starts_and_stops()
 		{
-			var serverPort = 8911;
-			Assert.IsTrue(!IsTcpPortListening(serverPort), "Tcp port should be closed before test starts.");
+			Assert.IsTrue(IsTcpPortListening(_serverPort), "Tcp port should be open when server has started.");
+			_server.Stop();
+			Assert.IsTrue(!IsTcpPortListening(_serverPort), "Tcp port should be closed when server has stopped.");
+		}
 
-			var server = new SimpleTcpServer().Start(serverPort);
-			Assert.IsTrue(IsTcpPortListening(serverPort), "Tcp port should be open when server has started.");
-
-			server.Stop();
-			Assert.IsTrue(!IsTcpPortListening(serverPort), "Tcp port should be closed when server has stopped.");
+		[TestMethod]
+		[ExpectedException(typeof(InvalidOperationException))]
+		public void Start_fails_if_all_nics_are_occupied()
+		{
+			var server2 = new SimpleTcpServer().Start(_serverPort);
+			server2.Stop(); //Guard-clause. Should never reach this.
 		}
 
 

--- a/SimpleTCP.Tests/ServerTests2.cs
+++ b/SimpleTCP.Tests/ServerTests2.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SimpleTCP.Tests
+{
+	[TestClass]
+	public class ServerTests2
+	{
+		readonly int _serverPort = 8911;
+
+		[TestMethod]
+		public void Start_passes_if_at_all_nics_passed()
+		{
+			var server = new SimpleTcpServer().Start(_serverPort, false);
+			Assert.IsTrue(server.IsStarted, "Server should have started");
+			server.Stop();
+		}
+
+		[TestMethod]
+		public void Start_passes_if_at_least_one_nic_is_free()
+		{
+			var listener = new System.Net.Sockets.TcpListener(new IPAddress(new byte[] { 127, 0, 0, 1 }), _serverPort);
+			listener.Start();
+			try
+			{
+				var server = new SimpleTcpServer().Start(_serverPort);
+				Assert.IsTrue(server.IsStarted, "Server should have started on free nics");
+				server.Stop();
+			}
+			finally
+			{
+				listener.Stop();
+			}
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(InvalidOperationException))]
+		public void Start_fails_if_at_all_nics_free_is_required()
+		{
+			var listener = new System.Net.Sockets.TcpListener(new IPAddress(new byte[] { 127, 0, 0, 1 }), _serverPort);
+			listener.Start();
+			try
+			{
+				var server = new SimpleTcpServer().Start(_serverPort, false);
+				Assert.IsTrue(server.IsStarted, "Server should have started on free nics");
+				server.Stop();
+			}
+			finally
+			{
+				listener.Stop();
+			}
+		}
+	}
+}

--- a/SimpleTCP.Tests/SimpleTCP.Tests.csproj
+++ b/SimpleTCP.Tests/SimpleTCP.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="CommTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ServerTests.cs" />
+    <Compile Include="ServerTests2.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SimpleTCP\SimpleTCP.csproj">


### PR DESCRIPTION
As is, there is no failure if a server start() fails because one or all interfaces are already occupied.

Now only trying to start listeners on interfaces with OperationalStatus = Up.
Made it optional to fail if any interface listener failed to start.

Added some debug logging.
