### PR TITLE
Fix: ClientDisconnected event not being triggered

### DIFF
--- a/SimpleTCP/Server/ServerListener.cs
+++ b/SimpleTCP/Server/ServerListener.cs
@@ -74,6 +74,19 @@ namespace SimpleTCP.Server
 			_listener.Stop();
         }
 
+	    
+	bool IsSocketConnected(Socket s)
+	{
+	    // https://stackoverflow.com/questions/2661764/how-to-check-if-a-socket-is-connected-disconnected-in-c
+	    bool part1 = s.Poll(1000, SelectMode.SelectRead);
+	    bool part2 = (s.Available == 0);
+	    if ((part1 && part2) || !s.Connected)
+		return false;
+	    else
+		return true;
+	}
+
+	    
         private void RunLoopStep()
         {
             if (_disconnectedClients.Count > 0)
@@ -99,6 +112,11 @@ namespace SimpleTCP.Server
 
             foreach (var c in _connectedClients)
             {
+		if ( IsSocketConnected(c.Client) == false)
+                {
+                    _disconnectedClients.Add(c);
+                }
+		    
                 int bytesAvailable = c.Available;
                 if (bytesAvailable == 0)
                 {
@@ -128,12 +146,7 @@ namespace SimpleTCP.Server
                 if (bytesReceived.Count > 0)
                 {
                     _parent.NotifyEndTransmissionRx(this, c, bytesReceived.ToArray());
-                }
-
-                if (!c.Connected)
-                {
-                    _disconnectedClients.Add(c);
-                }                
+                }z      
             }
         }
     }

--- a/SimpleTCP/Server/ServerListener.cs
+++ b/SimpleTCP/Server/ServerListener.cs
@@ -56,7 +56,8 @@ namespace SimpleTCP.Server
         internal TcpListenerEx Listener { get { return _listener; } }
 
 
-		private void ListenerLoop(object state)
+		
+	private void ListenerLoop(object state)
         {
             while (!QueueStop)
             {
@@ -112,6 +113,7 @@ namespace SimpleTCP.Server
 
             foreach (var c in _connectedClients)
             {
+		
 		if ( IsSocketConnected(c.Client) == false)
                 {
                     _disconnectedClients.Add(c);
@@ -146,7 +148,7 @@ namespace SimpleTCP.Server
                 if (bytesReceived.Count > 0)
                 {
                     _parent.NotifyEndTransmissionRx(this, c, bytesReceived.ToArray());
-                }z      
+                }  
             }
         }
     }


### PR DESCRIPTION
Hi Brandon,

I have a fix for the ClientDisconnected event not being triggered.  Its a small fix. Essentially it moves your test for "clients that have been disconnected" from the bottom of the "connected clients" loop to the top (above the continue statement).  

Next, I used the power of stack overflow to come up with a simpler helper function "IsSocketConnected" that does a couple of other checks in addition to testing the "Connected" property.

This works for me in my testing however totally understand if you don't wish to merge this.  

Great project by the way.  👍 

My sample code:

    class Program
    {
        static SimpleTcpServer server = null;
        static void Main(string[] args)
        {
            server = new SimpleTcpServer().Start(8910);

            server.ClientConnected += Server_ClientConnected;
            server.ClientDisconnected += Server_ClientDisconnected;
            server.DataReceived += Client_MessageReceived;

            Console.WriteLine("Starter Server. Press enter to stop...");
            Console.ReadLine();

            server.Stop();
        }

        static void Server_ClientConnected(object sender, TcpClient e)
        {
            Console.WriteLine("A new client is connected: {0}. Client Count: {1}", e.Client.RemoteEndPoint.ToString(), server.ConnectedClientsCount);
        }

        static void Server_ClientDisconnected(object sender, TcpClient e)
        {
            Console.WriteLine("A client is disconnected: {0}. Client Count: {1}", e.Client.RemoteEndPoint.ToString(), server.ConnectedClientsCount);
        }

        static void Client_MessageReceived(object sender, Message e)
        {
            Console.WriteLine("ClientId: {0} sent the message: {1}", e.TcpClient.Client.RemoteEndPoint.ToString(), e.MessageString);

            string reply = string.Format("Got it buddy! You sent: {0}", e.MessageString);
            Console.WriteLine("Sending Reply: {0}", reply);

            // Send Reply to Client
            e.ReplyLine(reply);
        }
    }