### PR TITLE
Followup for recent RankIPAddresses update - extract method TryGetCurrentNetworkInterfaces

### DIFF
--- a/SimpleTCP/SimpleTcpServer.cs
+++ b/SimpleTCP/SimpleTcpServer.cs
@@ -114,7 +114,7 @@ namespace SimpleTCP
 
             if (rankScore > 500)
             {
-                foreach (var nic in NetworkInterface.GetAllNetworkInterfaces().Where(ni => ni.OperationalStatus == OperationalStatus.Up))
+                foreach (var nic in TryGetCurrentNetworkInterfaces())
                 {
                     var ipProps = nic.GetIPProperties();
                     if (ipProps.GatewayAddresses.Any())
@@ -133,6 +133,18 @@ namespace SimpleTCP
             }
 
             return rankScore;
+        }
+
+        private static IEnumerable<NetworkInterface> TryGetCurrentNetworkInterfaces()
+        {
+            try
+            {
+                return NetworkInterface.GetAllNetworkInterfaces().Where(ni => ni.OperationalStatus == OperationalStatus.Up);
+            }
+            catch (NetworkInformationException)
+            {
+                return Enumerable.Empty<NetworkInterface>();
+            }
         }
 
         public SimpleTcpServer Start(int port, bool ignoreNicsWithOccupiedPorts = true)


### PR DESCRIPTION
This adds a try/catch handler around a previously unprotected call to GetAlllNetworkInterfaces, and simply does not boost the ranking if an error occurs when checking whether the NIC is the default router. (The extracted method could also be enhanced further to cache the result for a few seconds, to avoid repeated calls, but it doesn't do that right now.)