### PR TITLE
Add support for .NET 4.0 projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Want to receive a message event on the server each time you see a newline \n (ch
 ```cs
 server.Delimiter = 0x13;
 server.DelimiterDataReceived += (sender, msg) => {
-                msg.ReplyLine("You said: " + msg.MessageString);
+                msg.Message.ReplyLine("You said: " + msg.Message.MessageString);
             };
 ```
 

--- a/SimpleTCP.Tests/CommTest.cs
+++ b/SimpleTCP.Tests/CommTest.cs
@@ -21,14 +21,14 @@ namespace SimpleTCP.Tests
             SimpleTcpClient client = new SimpleTcpClient().Connect(server.GetListeningIPs().FirstOrDefault(ip => ip.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork).ToString(), 8910);
 
             server.DelimiterDataReceived += (sender, msg) => {
-                _serverRx.Add(msg.MessageString);
+                _serverRx.Add(msg.Message.MessageString);
                 string serverReply = Guid.NewGuid().ToString();
-                msg.ReplyLine(serverReply);
+                msg.Message.ReplyLine(serverReply);
                 _serverTx.Add(serverReply);
             };
 
             client.DelimiterDataReceived += (sender, msg) => {
-                _clientRx.Add(msg.MessageString);
+                _clientRx.Add(msg.Message.MessageString);
             };
 
             System.Threading.Thread.Sleep(1000);

--- a/SimpleTCP/MessageEventArgs.cs
+++ b/SimpleTCP/MessageEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace SimpleTCP
+{
+    public class MessageEventArgs : EventArgs
+    {
+        public Message Message { get; set; }
+
+        public MessageEventArgs(Message message)
+        {
+            this.Message = message;
+        }
+    }
+}

--- a/SimpleTCP/SimpleTCP.csproj
+++ b/SimpleTCP/SimpleTCP.csproj
@@ -42,12 +42,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Message.cs" />
+    <Compile Include="MessageEventArgs.cs" />
     <Compile Include="Server\ConnectedClient.cs" />
     <Compile Include="Server\ServerListener.cs" />
     <Compile Include="Server\TcpListenerEx.cs" />
     <Compile Include="SimpleTcpClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SimpleTcpServer.cs" />
+    <Compile Include="TcpClientEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="SimpleTCP.nuspec" />

--- a/SimpleTCP/SimpleTCP.csproj
+++ b/SimpleTCP/SimpleTCP.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SimpleTCP</RootNamespace>
     <AssemblyName>SimpleTCP</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/SimpleTCP/SimpleTcpClient.cs
+++ b/SimpleTCP/SimpleTcpClient.cs
@@ -24,8 +24,8 @@ namespace SimpleTCP
 		public System.Text.Encoding StringEncoder { get; set; }
 		private TcpClient _client = null;
 
-		public event EventHandler<Message> DelimiterDataReceived;
-		public event EventHandler<Message> DataReceived;
+		public event EventHandler<MessageEventArgs> DelimiterDataReceived;
+		public event EventHandler<MessageEventArgs> DataReceived;
 
 		internal bool QueueStop { get; set; }
 		internal int ReadLoopIntervalMs { get; set; }
@@ -129,7 +129,8 @@ namespace SimpleTCP
 			if (DelimiterDataReceived != null)
 			{
 				Message m = new Message(msg, client, StringEncoder, Delimiter, AutoTrimStrings);
-				DelimiterDataReceived(this, m);
+                MessageEventArgs args = new MessageEventArgs(m);
+				DelimiterDataReceived(this, args);
 			}
 		}
 
@@ -138,7 +139,8 @@ namespace SimpleTCP
 			if (DataReceived != null)
 			{
 				Message m = new Message(msg, client, StringEncoder, Delimiter, AutoTrimStrings);
-				DataReceived(this, m);
+                MessageEventArgs args = new MessageEventArgs(m);
+				DataReceived(this, args);
 			}
 		}
 
@@ -170,7 +172,7 @@ namespace SimpleTCP
 		public Message WriteLineAndGetReply(string data, TimeSpan timeout)
 		{
 			Message mReply = null;
-			this.DataReceived += (s, e) => { mReply = e; };
+			this.DataReceived += (s, e) => { mReply = e.Message; };
 			WriteLine(data);
 
 			Stopwatch sw = new Stopwatch();

--- a/SimpleTCP/SimpleTcpServer.cs
+++ b/SimpleTCP/SimpleTcpServer.cs
@@ -24,10 +24,10 @@ namespace SimpleTCP
         public System.Text.Encoding StringEncoder { get; set; }
         public bool AutoTrimStrings { get; set; }
 
-        public event EventHandler<TcpClient> ClientConnected;
-        public event EventHandler<TcpClient> ClientDisconnected;
-        public event EventHandler<Message> DelimiterDataReceived;
-        public event EventHandler<Message> DataReceived;
+        public event EventHandler<TcpClientEventArgs> ClientConnected;
+        public event EventHandler<TcpClientEventArgs> ClientDisconnected;
+        public event EventHandler<MessageEventArgs> DelimiterDataReceived;
+        public event EventHandler<MessageEventArgs> DataReceived;
 
         public IEnumerable<IPAddress> GetIPAddresses()
         {
@@ -222,7 +222,8 @@ namespace SimpleTCP
             if (DelimiterDataReceived != null)
             {
                 Message m = new Message(msg, client, StringEncoder, Delimiter, AutoTrimStrings);
-                DelimiterDataReceived(this, m);
+                MessageEventArgs args = new MessageEventArgs(m);
+                DelimiterDataReceived(this, args);
             }
         }
 
@@ -231,7 +232,8 @@ namespace SimpleTCP
             if (DataReceived != null)
             {
                 Message m = new Message(msg, client, StringEncoder, Delimiter, AutoTrimStrings);
-                DataReceived(this, m);
+                MessageEventArgs args = new MessageEventArgs(m);
+                DataReceived(this, args);
             }
         }
 
@@ -239,7 +241,8 @@ namespace SimpleTCP
         {
             if (ClientConnected != null)
             {
-                ClientConnected(this, newClient);
+                TcpClientEventArgs args = new TcpClientEventArgs(newClient);
+                ClientConnected(this, args);
             }
         }
 
@@ -247,7 +250,8 @@ namespace SimpleTCP
         {
             if (ClientDisconnected != null)
             {
-                ClientDisconnected(this, disconnectedClient);
+                TcpClientEventArgs args = new TcpClientEventArgs(disconnectedClient);
+                ClientDisconnected(this, args);
             }
         }
 

--- a/SimpleTCP/TcpClientEventArgs.cs
+++ b/SimpleTCP/TcpClientEventArgs.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Net.Sockets;
+
+namespace SimpleTCP
+{
+    public class TcpClientEventArgs : EventArgs
+    {
+        public TcpClient TcpClient { get; set; }
+
+        public TcpClientEventArgs(TcpClient tcpClient)
+        {
+            this.TcpClient = tcpClient;
+        }
+    }
+}


### PR DESCRIPTION
Clean, simple TCP client/server implementations are hard to come by on .NET 4.0.  This project requires .NET 4.5, but with the requested modifications, that constraint could be lowered.  There's a host of projects I'm working on where a requirement is that they work on older versions of Windows that don't support anything newer than .NET 4.0

I'm not sure how invasive requests like these are; thanks for posting this project.